### PR TITLE
fix: command sync code

### DIFF
--- a/core/Event.py
+++ b/core/Event.py
@@ -1,12 +1,13 @@
 import datetime
-import os, importlib
+import os
 
 import discord
-from discord.ext import commands, tasks
+from discord.ext import commands
 from sqlalchemy import and_
 
 import utils.Logs as logs
 import utils.Utility as util
+from main import MynaBot
 from utils.Role import *
 from utils.database.Database import SessionContext
 from utils.database.model.status import Status
@@ -15,9 +16,9 @@ from utils.database.model.users import Users
 
 class Event(commands.Cog):
 
-    def __init__(self, bot):
+    def __init__(self, bot: MynaBot):
         print(f'{type(self).__name__}가 로드되었습니다.')
-        self.bot = bot
+        self.bot: MynaBot = bot
         self.core_list = ['Administrator', 'Command', 'Profile']
 
         if util.is_test_version():
@@ -48,7 +49,10 @@ class Event(commands.Cog):
                 activity=discord.Game(f"{sum(map(lambda x: x.member_count, self.bot.guilds))} 명이 이용")
         )
 
+        # load core modules
         await self.load_core()
+        # sync slash commands
+        await self.bot.tree.sync()
 
         with SessionContext() as session:
             # FIXME: boot_time 제대로 갱신이 안됨

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ class MynaBot(commands.Bot):
             self.owner_id = self.bot_app_info.owner.id
 
     async def on_ready(self) -> None:
-        await self.tree.sync()
+        ...
 
     async def start(self, token) -> None:
         return await super().start(token, reconnect=True)  # type: ignore


### PR DESCRIPTION
sync 함수가 제대로 작동하지 않는다고 생각했으나, 결국 내 실수였음.

1. MynaBot의 on_ready()에서 tree.sync()를 통해 동기화를 하고 있음.
2. 그런데 여기서 그 이후 Event 모듈에 의해서 다른 Core 모듈이 로드됨.
3. 동기화 시점에서는 명령어가 로드되지 않았으므로 디스코드에서는 없는 명령어라고 뜸...

그래서 해결방법은 Event 모듈의 on_ready()에서 다른 Core 모듈을 로드한 후에 sync()로 동기화하면 된다.